### PR TITLE
modify preview_markdown_parser to enable use flag

### DIFF
--- a/autoload/preview_markdown.vim
+++ b/autoload/preview_markdown.vim
@@ -51,7 +51,7 @@ function! preview_markdown#preview() abort
   let bin = split(parser,' ')[0]
 
   if !executable(bin)
-    call s:echo_err(printf('%s not found, please install %s', parser, bin))
+    call s:echo_err(printf('%s not found, please install %s', bin, bin))
     return
   endif
 

--- a/autoload/preview_markdown.vim
+++ b/autoload/preview_markdown.vim
@@ -48,9 +48,10 @@ function! preview_markdown#preview() abort
   call writefile(getline(1, "$"), tmp)
 
   let parser = get(g:, 'preview_markdown_parser', 'mdr')
+  let bin = split(parser,' ')[0]
 
-  if !executable(parser)
-    call s:echo_err(printf('%s not found, please install %s', parser, parser))
+  if !executable(bin)
+    call s:echo_err(printf('%s not found, please install %s', parser, bin))
     return
   endif
 


### PR DESCRIPTION
Hi!

I tryed to use this plugin with [glow](https://github.com/charmbracelet/glow) , but preview displayed without color.
And When I use with glow with pager by `glow -p` flag ,it seems to work well.

So, I modifyed `g: preview_markdown_parser` to enable command with flags.
Please Review this PR.

Thanks!

## my environment
```
vim --version
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Nov 17 2020 01:45:54)
macOS 版
適用済パッチ: 1-2000
Compiled by Homebrew
Huge 版 without GUI.  機能の一覧 有効(+)/無効(-)
+acl               -farsi             +mouse_sgr         +tag_binary
+arabic            +file_in_path      -mouse_sysmouse    -tag_old_static
+autocmd           +find_in_path      +mouse_urxvt       -tag_any_white
+autochdir         +float             +mouse_xterm       -tcl
-autoservername    +folding           +multi_byte        +termguicolors
-balloon_eval      -footer            +multi_lang        +terminal
+balloon_eval_term +fork()            -mzscheme          +terminfo
-browse            +gettext           +netbeans_intg     +termresponse
++builtin_terms    -hangul_input      +num64             +textobjects
+byte_offset       +iconv             +packages          +textprop
+channel           +insert_expand     +path_extra        +timers
+cindent           +ipv6              +perl              +title
-clientserver      +job               +persistent_undo   -toolbar
+clipboard         +jumplist          +popupwin          +user_commands
+cmdline_compl     +keymap            +postscript        +vartabs
+cmdline_hist      +lambda            +printer           +vertsplit
+cmdline_info      +langmap           +profile           +virtualedit
+comments          +libcall           -python            +visual
+conceal           +linebreak         +python3           +visualextra
+cryptv            +lispindent        +quickfix          +viminfo
+cscope            +listcmds          +reltime           +vreplace
+cursorbind        +localmap          +rightleft         +wildignore
+cursorshape       +lua               +ruby              +wildmenu
+dialog_con        +menu              +scrollbind        +windows
+diff              +mksession         +signs             +writebackup
+digraphs          +modify_fname      +smartindent       -X11
-dnd               +mouse             -sound             -xfontset
-ebcdic            -mouseshape        +spell             -xim
+emacs_tags        +mouse_dec         +startuptime       -xpm
+eval              -mouse_gpm         +statusline        -xsmp
+ex_extra          -mouse_jsbterm     -sun_workshop      -xterm_clipboard
+extra_search      +mouse_netterm     +syntax            -xterm_save
      システム vimrc: "$VIM/vimrc"
      ユーザー vimrc: "$HOME/.vimrc"
   第2ユーザー vimrc: "~/.vim/vimrc"
       ユーザー exrc: "$HOME/.exrc"
  デフォルトファイル: "$VIMRUNTIME/defaults.vim"
       省略時の $VIM: "/usr/local/share/vim"
コンパイル: clang -c -I. -Iproto -DHAVE_CONFIG_H   -DMACOS_X -DMACOS_X_DARWIN  -g -O2 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1
リンク: clang   -L. -fstack-protector-strong -L/usr/local/lib -L/usr/local/opt/libyaml/lib -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/readline/lib  -L/usr/local/lib -o vim        -lncurses -liconv -lintl -framework AppKit  -L/usr/local/opt/lua/lib -llua5.3 -mmacosx-version-min=10.14 -fstack-protector-strong -L/usr/local/lib  -L/usr/local/Cellar/perl/5.32.0/lib/perl5/5.32.0/darwin-thread-multi-2level/CORE -lperl -lm -lutil -lc  -L/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9/lib/python3.9/config-3.9-darwin -lpython3.9 -framework CoreFoundation  -lruby.2.7
```

