### PR TITLE
Add auto_update feature for neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ repo = 'skanehira/preview-markdown.vim'
 ```
 
 ## Options
-| option                           | description                                                             |
-|----------------------------------|-------------------------------------------------------------------------|
-| `g:preview_markdown_parser`      | Use specified command to parse markdown, default is `mdr`               |
-| `g:preview_markdown_auto_update` | Update preview window when write to buffer. This unstill support Neovim |
+| option                           | description                                               |
+|----------------------------------|-----------------------------------------------------------|
+| `g:preview_markdown_parser`      | Use specified command to parse markdown, default is `mdr` |
+| `g:preview_markdown_auto_update` | Update preview window when write to buffer.               |
 
 ## Markdown parser
 - [MichaelMure/mdr](https://github.com/MichaelMure/mdr)

--- a/autoload/preview_markdown.vim
+++ b/autoload/preview_markdown.vim
@@ -28,7 +28,7 @@ function! s:stop_job() abort
     if s:jobid isnot# v:null
       call jobstop(s:jobid)
       if bufexists(s:preview_buf_nr)
-          execute "bd! " . s:preview_buf_nr
+          execute "bw! " . s:preview_buf_nr
       endif
     endif
   else

--- a/doc/preview_markdown.txt
+++ b/doc/preview_markdown.txt
@@ -76,7 +76,6 @@ g:preview_markdown_parser			*g:preview_markdown_parser*
 g:preview_markdown_auto_update			*g:preview_markdown_auto_update*
 	If you want to auto update preview window
 	when you write to buffer, please set value to 1.
-	NOTE: This unstill support Neovim.
 
 ==============================================================================
 TODO						*preview_markdown-todo*


### PR DESCRIPTION
Hi,
I'm really sorry to send the same pull request twice.
Since I forgot to make a branch before sending the pull request, I tried to fix it but accidentally closed the previous pull request.

This commits allows to use auto_update feature for Neovim users.

- To save a job id that is made by `termopen`, I made a new variable `s:preview_job_id`.

- To close the buffer of a terminated terminal, I added the following lines:
```
  if has('nvim')
    autocmd TermClose * exe "bd! " . expand('<abuf>')
  endif
```