### PR TITLE
Fix E916 error on windows10

### DIFF
--- a/autoload/preview_markdown.vim
+++ b/autoload/preview_markdown.vim
@@ -23,7 +23,7 @@ endfunction
 
 function! s:stop_job() abort
   let s:jobid = term_getjob(bufnr('%'))
-  if s:jobid isnot# v:null
+  if ((s:jobid isnot# v:null) && (s:jobid !=# 'no process'))
     call job_stop(s:jobid)
     let c = 0
     while job_status(s:jobid) is# 'run'


### PR DESCRIPTION
The return of term_getjob(bufnr('%')) on windows10 is 'no process'
rather than v:null.
Add an extra condition for the s:stop_job()